### PR TITLE
fixed to case-sensetive-search

### DIFF
--- a/js/components/SelectPermissionSet.jsx
+++ b/js/components/SelectPermissionSet.jsx
@@ -14,11 +14,15 @@ var Highlight = React.createClass({
 render: function() {
 	var word = this.props.word;
 	var value = this.props.value;
+	function replacer(sub) {
+		return "<strong style='background: rgba(43, 53, 183, 0.85); color: #fff;' className\"match\">"+ sub +"</strong>"
+	}
 	return (
 		<td><span
-		dangerouslySetInnerHTML={{
-			__html : value.replace(word, "<strong style='background: rgba(43, 53, 183, 0.85); color: #fff;' className\"match\">" + word + "</strong>")
-		}} /></td>
+			dangerouslySetInnerHTML={{
+				__html : value.replace(new RegExp(word, 'ig'), replacer)
+			}} 
+		/></td>
 	);
 }
 });
@@ -48,8 +52,12 @@ var TableOfPermissions = React.createClass({
   render: function() {
 	var rows = [];
 	this.props.products.forEach(function(product) {
+		// check difference between value from search and words from table
 		if (product.name.indexOf(this.props.filterText) === -1 && product.type.indexOf(this.props.filterText) === -1 && product.option.indexOf(this.props.filterText) === -1) {
-			return;
+			//check difference between value from search and words from table ignoring case sensitive
+			if (product.name.toLowerCase().indexOf(this.props.filterText.toLowerCase()) === -1 && product.type.toLowerCase().indexOf(this.props.filterText.toLowerCase()) === -1 && product.option.toLowerCase().indexOf(this.props.filterText.toLowerCase()) === -1) {
+				return;
+			}
 		}
 		rows.push(<PermissionsRow product={product} key={product.name} filterText={this.props.filterText} />);
 	}.bind(this));


### PR DESCRIPTION
Idea with regular expression is pretty good.

However there is one place with not good code quality - render() method in SelectPermissionSet.jsx. Too many instances of the same code:
`product.name.toLowerCase().indexOf(this.props.filterText.toLowerCase()) === -1`

We definitely can rewrite it in something similar to:

``` javascript
const key = this.props.filterText;
this.props.products.forEach(function(product) {
  if ( matchFound(product.name, key) ||
       matchFound(product.type, key) ||
       matchFound(product.option, key) ) {
    rows.push(<PermissionsRow product={product} key={product.name} filterText={this.props.filterText} />);
  }
}.bind(this));
```

where matchFound() is a function to match key inside a string.
